### PR TITLE
[WIP] Allow loading optimizer state

### DIFF
--- a/training/load_deepspeed_checkpoints.py
+++ b/training/load_deepspeed_checkpoints.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python
+
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+# This script extracts fp32 consolidated weights from a zero 2 and 3 DeepSpeed checkpoints. It gets
+# copied into the top level checkpoint dir, so the user can easily do the conversion at any point in
+# the future. Once extracted, the weights don't require DeepSpeed and can be used in any
+# application.
+#
+# example: python zero_to_fp32.py . pytorch_model.bin
+import torch
+import glob
+import math
+import os
+import re
+from collections import OrderedDict
+
+
+debug = 0
+
+SINGLE_PARTITION_OF_FP32_GROUPS = 'single_partition_of_fp32_groups'
+OPTIMIZER_STATE_DICT = 'optimizer_state_dict'
+FP32_FLAT_GROUPS = 'fp32'
+ZERO_STAGE = 'zero_stage'
+PARTITION_COUNT = 'partition_count'
+PARAM_SHAPES = 'param_shapes'
+BUFFER_NAMES = 'buffer_names'
+
+# load to cpu
+device = torch.device('cpu')
+
+
+def atoi(text):
+    return int(text) if text.isdigit() else text
+
+
+def natural_keys(text):
+    '''
+    alist.sort(key=natural_keys) sorts in human order
+    http://nedbatchelder.com/blog/200712/human_sorting.html
+    (See Toothy's implementation in the comments)
+    '''
+    return [atoi(c) for c in re.split(r'(\d+)', text)]
+
+
+def get_model_state_file(checkpoint_dir, zero_stage):
+    if not os.path.isdir(checkpoint_dir):
+        raise FileNotFoundError(f"Directory '{checkpoint_dir}' doesn't exist")
+
+    # there should be only one file
+    if zero_stage == 2:
+        file = os.path.join(checkpoint_dir, "mp_rank_00_model_states.pt")
+    elif zero_stage == 3:
+        file = os.path.join(checkpoint_dir, "zero_pp_rank_0_mp_rank_00_model_states.pt")
+
+    if not os.path.exists(file):
+        raise FileNotFoundError(f"can't find model states file at '{file}'")
+
+    return file
+
+
+def get_optim_files(checkpoint_dir):
+    # XXX: need to test that this simple glob rule works for multi-node setup too
+    optim_files = sorted(glob.glob(os.path.join(checkpoint_dir, "*_optim_states.pt")), key=natural_keys)
+
+    if len(optim_files) == 0:
+        raise FileNotFoundError(f"can't find '*_optim_states.pt' files in directory '{checkpoint_dir}'")
+
+    return optim_files
+
+
+def parse_model_state(file):
+    state_dict = torch.load(file, map_location=device)
+
+    # if BUFFER_NAMES not in state_dict:
+    #     raise ValueError(f"{file} is not a model state checkpoint")
+    buffer_names = state_dict#[BUFFER_NAMES]
+    if debug:
+        print("Found buffers:", buffer_names)
+
+    # recover just the buffers while restoring them to fp32 if they were saved in fp16
+    buffers = {k: v.float() for k, v in state_dict["module"].items() if k in buffer_names}
+    param_shapes = state_dict[PARAM_SHAPES]
+
+    # collect parameters that are included in param_shapes
+    param_names = []
+    for s in param_shapes:
+        for name in s.keys():
+            param_names.append(name)
+
+    # record shared parameters so that they can be recovered based on partners
+    # this is because such parameters holding reference only are not saved by optimizer
+    shared_params = []
+    for param in state_dict["module"]:
+        if param not in [*param_names, *buffer_names]:
+            for share_param in state_dict["module"]:
+                if (state_dict["module"][share_param].data_ptr() == state_dict["module"][param].data_ptr()
+                        and share_param != param):
+                    shared_params.append([param, share_param])
+                    break
+
+    ds_version = state_dict.get(DS_VERSION, None)
+
+    return buffers, param_shapes, shared_params, ds_version
+
+
+def parse_optim_states(files, ds_checkpoint_dir):
+
+    total_files = len(files)
+    state_dicts = []
+    for f in files:
+        state_dicts.append(torch.load(f, map_location=device))
+
+    if not ZERO_STAGE in state_dicts[0][OPTIMIZER_STATE_DICT]:
+        raise ValueError(f"{files[0]} is not a zero checkpoint")
+    zero_stage = state_dicts[0][OPTIMIZER_STATE_DICT][ZERO_STAGE]
+    world_size = state_dicts[0][OPTIMIZER_STATE_DICT][PARTITION_COUNT]
+
+    # For ZeRO-2 each param group can have different partition_count as data parallelism for expert
+    # parameters can be different from data parallelism for non-expert parameters. So we can just
+    # use the max of the partition_count to get the dp world_size.
+
+    if type(world_size) is list:
+        world_size = max(world_size)
+
+    if world_size != total_files:
+        raise ValueError(
+            f"Expected {world_size} of '*_optim_states.pt' under '{ds_checkpoint_dir}' but found {total_files} files. "
+            "Possibly due to an overwrite of an old checkpoint, or a checkpoint didn't get saved by one or more processes."
+        )
+
+    # the groups are named differently in each stage
+    if zero_stage == 1:
+        zero_stage = 2
+        SINGLE_PARTITION_OF_FP32_GROUPS = 'local_sub_partitions_of_fp32_groups'
+    if zero_stage == 2:
+        fp32_groups_key = SINGLE_PARTITION_OF_FP32_GROUPS
+    elif zero_stage == 3:
+        fp32_groups_key = FP32_FLAT_GROUPS
+    else:
+        raise ValueError(f"unknown zero stage {zero_stage}")
+    
+    if zero_stage == 2:
+        fp32_flat_groups = [state_dicts[i][OPTIMIZER_STATE_DICT][fp32_groups_key] for i in range(len(state_dicts))]
+        base_opt_state = [state_dicts[i][OPTIMIZER_STATE_DICT]['base_optimizer_state'] for i in range(len(state_dicts))]
+        # unpack base opt state
+        exp_avg = []
+        exp_avg_sq = []
+        for state in base_opt_state:
+            for substate in state:
+                exp_avg.append(substate[0]['exp_avg'])
+                exp_avg_sq.append(substate[0]['exp_avg_sq'])
+    elif zero_stage == 3:
+        # if there is more than one param group, there will be multiple flattened tensors - one
+        # flattened tensor per group - for simplicity merge them into a single tensor
+        #
+        # XXX: could make the script more memory efficient for when there are multiple groups - it
+        # will require matching the sub-lists of param_shapes for each param group flattened tensor
+
+        fp32_flat_groups = [
+            torch.cat(state_dicts[i][OPTIMIZER_STATE_DICT][fp32_groups_key], 0) for i in range(len(state_dicts))
+        ]
+
+    return zero_stage, world_size, fp32_flat_groups, state_dicts[0]['param_shapes'], exp_avg, exp_avg_sq
+
+
+
+def _get_fp32_state_dict_from_zero2_checkpoint(world_size, param_shapes, fp32_flat_groups, buffers, shared_params):
+
+    # Reconstruction protocol:
+    #
+    # XXX: document this
+    debug = True
+
+    # if debug:
+    #     for i in range(world_size):
+    #         for j in range(len(fp32_flat_groups[0])):
+    #             print(f"{FP32_FLAT_GROUPS}[{i}][{j}].shape={fp32_flat_groups[i][j].shape}")
+
+    # XXX: memory usage doubles here (zero2)
+    num_param_groups = len(fp32_flat_groups[0])
+    merged_single_partition_of_fp32_groups = []
+    for i in range(1):
+        #merged_partitions = [sd[i] for sd in fp32_flat_groups]
+        full_single_fp32_vector = torch.cat(fp32_flat_groups, 0)
+        merged_single_partition_of_fp32_groups.append(full_single_fp32_vector)
+        
+    print('merged')
+    avail_numel = sum(
+        [full_single_fp32_vector.numel() for full_single_fp32_vector in merged_single_partition_of_fp32_groups])
+
+    # if debug:
+    #     wanted_params = sum([len(shapes) for shapes in param_shapes.values()])
+    #     wanted_numel = sum([sum(shape.numel() for shape in shapes) for shapes in param_shapes.values()])
+    #     # not asserting if there is a mismatch due to possible padding
+    #     print(f"Have {avail_numel} numels to process.")
+    #     print(f"Need {wanted_numel} numels in {wanted_params} params.")
+
+    state_dict = OrderedDict()
+
+    # # buffers
+    # state_dict.update(buffers)
+    # if debug:
+    #     print(f"added {len(buffers)} buffers")
+
+    # params
+    # XXX: for huge models that can't fit into the host's RAM we will have to recode this to support
+    # out-of-core computing solution
+    total_numel = 0
+    total_params = 0
+    #import pdb; pdb.set_trace()
+    list_of_shapes = [shapes for shapes in param_shapes.values()]
+    print(param_shapes)
+    full_single_fp32_vector = torch.cat(merged_single_partition_of_fp32_groups)
+    #import pdb; pdb.set_trace()
+    offset = 0
+    for shapes in param_shapes.items():
+        avail_numel = full_single_fp32_vector.numel()
+        name, shape = shapes
+
+        unpartitioned_numel = shape.numel()
+        total_numel += unpartitioned_numel
+        total_params += 1
+
+        if debug:
+            print(f"{name} full shape: {shape} unpartitioned numel {unpartitioned_numel} offset {offset}")
+        state_dict[name] = full_single_fp32_vector.narrow(0, offset, unpartitioned_numel).view(shape)
+        offset += unpartitioned_numel
+
+        # Z2 started to align to 2*world_size to improve nccl performance. Therefore both offset and
+        # avail_numel can differ by anywhere between 0..2*world_size. Due to two unrelated complex
+        # paddings performed in the code it's almost impossible to predict the exact numbers w/o the
+        # live optimizer object, so we are checking that the numbers are within the right range
+        align_to = 2 * world_size
+
+        def zero2_align(x):
+            return align_to * math.ceil(x / align_to)
+
+        if debug:
+            print(f"original offset={offset}, avail_numel={avail_numel}")
+
+        offset = zero2_align(offset)
+        avail_numel = zero2_align(avail_numel)
+
+        if debug:
+            print(f"aligned  offset={offset}, avail_numel={avail_numel}")
+
+        # Sanity check
+    if offset != avail_numel:
+        raise ValueError(f"consumed {offset} numels out of {avail_numel} - something is wrong")
+
+    # recover shared parameters
+    # for pair in shared_params:
+    #     state_dict[pair[0]] = state_dict[pair[1]]
+
+    print(f"Reconstructed fp32 state dict with {total_params} params {total_numel} elements")
+
+    return state_dict
+
+
+def get_optimizer_state_from_checkpoint(ds_checkpoint_dir, model, optimizer):
+    """
+    Returns fp32 state_dict reconstructed from ds checkpoint
+
+    Args:
+        - ``ds_checkpoint_dir``: path to the deepspeed checkpoint folder (where the optimizer files are)
+
+    """
+    print(f"Processing zero checkpoint '{ds_checkpoint_dir}'")
+    optim_files = get_optim_files(ds_checkpoint_dir)
+    zero_stage, world_size, fp32_flat_groups, param_shapes, exp_avg, exp_avg_sq = parse_optim_states(optim_files, ds_checkpoint_dir)
+    param_shapes = {k: v for k, v in param_shapes.items()}
+    print(f"Detected checkpoint of type zero stage {zero_stage}, world_size: {world_size}")
+    # grab train step
+    step = torch.load(os.path.join(ds_checkpoint_dir, 'mp_rank_00_model_states.pt'))['global_steps']
+
+    # model_file = get_model_state_file(ds_checkpoint_dir, zero_stage)
+    # buffers, param_shapes, shared_params, ds_version = parse_model_state(model_file)
+    # print(f'Parsing checkpoint created by deepspeed=={ds_version}')
+    print('exp avg...')
+    exp_avg = _get_fp32_state_dict_from_zero2_checkpoint(world_size, param_shapes, exp_avg, None, None)
+    print('exp avg square...')
+    exp_avg_sq = _get_fp32_state_dict_from_zero2_checkpoint(world_size, param_shapes, exp_avg_sq, None, None)
+    print('plumbing into optimizer...')
+    # to make life easier, load in a model.
+    input_dummy = torch.tensor([[1, 2, 3]])
+    loss = model(input_dummy, labels=input_dummy).loss
+    loss.backward()
+    optimizer.step()
+    optimizer.zero_grad()
+    state_dict = optimizer.state_dict()
+    # get the right ordering of params
+    no_decay = ["bias", "layer_norm.weight"]
+    param_groups = [
+        # [n for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)],
+        # [n for n, p in model.named_parameters() if any(nd in n for nd in no_decay)],
+    ]
+    param_groups = [n for n, _ in model.named_parameters()] #param_groups[0] + param_groups[1]
+    def convert_hf_name(name):
+        name = name.replace('gpt_neox.', '')
+        name = name.replace('layers.', '')
+        if name[0].isdigit():
+            layer_num = int(name.split(".")[0]) + 2
+            name = ".".join(name.split(".")[1:])
+            name = f"{layer_num}.{name}"
+        elif name == 'final_layer_norm.weight':
+            name = '15.norm.weight'
+        elif name == 'final_layer_norm.bias':
+            name = '15.norm.bias'
+        elif name == 'embed_out.weight':
+            name = '16.final_linear.weight'
+        elif name == 'embed_in.weight':
+            name = '0.word_embeddings.weight'
+        else:
+            import pdb; pdb.set_trace()
+        return name
+
+    for i, name in enumerate(param_groups):
+        converted_name = convert_hf_name(name)
+        if state_dict['state'][i]['exp_avg'].shape != exp_avg[converted_name].shape:
+            import pdb; pdb.set_trace()
+        assert state_dict['state'][i]['exp_avg'].shape == exp_avg[converted_name].shape, f"{state_dict['state'][i]['exp_avg'].shape} != {exp_avg[converted_name].shape}: {converted_name}"
+        assert state_dict['state'][i]['exp_avg_sq'].shape == exp_avg_sq[converted_name].shape, f"{state_dict['state'][i]['exp_avg_sq'].shape} != {exp_avg_sq[converted_name].shape}: {name}"
+        state_dict['state'][i]['exp_avg'] = exp_avg[converted_name]
+        state_dict['state'][i]['exp_avg_sq'] = exp_avg_sq[converted_name]
+        state_dict['state'][i]['step'] = step
+    return state_dict, step

--- a/training/run_clm_no_trainer.py
+++ b/training/run_clm_no_trainer.py
@@ -394,7 +394,6 @@ def main():
     def tokenize_function(examples):
         return tokenizer(examples[text_column_name])
 
-
     with accelerator.main_process_first():
         tokenized_datasets = raw_datasets.map(
             tokenize_function,
@@ -468,16 +467,16 @@ def main():
     # Optimizer
     # Split weights in two groups, one with weight decay and the other not.
     no_decay = ["bias", "layer_norm.weight"]
-    # optimizer_grouped_parameters = [
-    #     {
-    #         "params": [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)],
-    #         "weight_decay": args.weight_decay,
-    #     },
-    #     {
-    #         "params": [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)],
-    #         "weight_decay": 0.0,
-    #     },
-    # ]
+    optimizer_grouped_parameters = [
+        {
+            "params": [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)],
+            "weight_decay": args.weight_decay,
+        },
+        {
+            "params": [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)],
+            "weight_decay": 0.0,
+        },
+    ]
     optimizer = torch.optim.Adam(model.parameters(), lr=args.learning_rate)
 
 

--- a/training/run_clm_no_trainer.py
+++ b/training/run_clm_no_trainer.py
@@ -477,7 +477,7 @@ def main():
             "weight_decay": 0.0,
         },
     ]
-    optimizer = torch.optim.Adam(model.parameters(), lr=args.learning_rate)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.learning_rate)
 
 
 

--- a/training/run_clm_no_trainer.py
+++ b/training/run_clm_no_trainer.py
@@ -216,6 +216,12 @@ def parse_args():
             "Only applicable when `--with_tracking` is passed."
         ),
     )
+    parser.add_argument(
+        "--optimizer_state",
+        type=str,
+        default=None,
+        help="Path to a saved optimizer state to load (can be used to resume training).",
+    )
     args = parser.parse_args()
 
     # Sanity checks
@@ -388,6 +394,8 @@ def main():
     def tokenize_function(examples):
         return tokenizer(examples[text_column_name])
 
+    raw_datasets['train'] = raw_datasets['train'].select(range(1000))
+
     with accelerator.main_process_first():
         tokenized_datasets = raw_datasets.map(
             tokenize_function,
@@ -461,17 +469,19 @@ def main():
     # Optimizer
     # Split weights in two groups, one with weight decay and the other not.
     no_decay = ["bias", "layer_norm.weight"]
-    optimizer_grouped_parameters = [
-        {
-            "params": [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)],
-            "weight_decay": args.weight_decay,
-        },
-        {
-            "params": [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)],
-            "weight_decay": 0.0,
-        },
-    ]
-    optimizer = torch.optim.AdamW(optimizer_grouped_parameters, lr=args.learning_rate)
+    # optimizer_grouped_parameters = [
+    #     {
+    #         "params": [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)],
+    #         "weight_decay": args.weight_decay,
+    #     },
+    #     {
+    #         "params": [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)],
+    #         "weight_decay": 0.0,
+    #     },
+    # ]
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.learning_rate)
+
+
 
     # Scheduler and math around the number of training steps.
     overrode_max_train_steps = False
@@ -487,9 +497,18 @@ def main():
         num_training_steps=args.max_train_steps * args.gradient_accumulation_steps,
     )
 
+    # loading the optimize state e.g. from pythia checkpoints
+    if args.optimizer_state:
+        from load_deepspeed_checkpoints import get_optimizer_state_from_checkpoint
+        state_dict, step = get_optimizer_state_from_checkpoint(args.optimizer_state, model, optimizer)
+        optimizer.load_state_dict(state_dict)
+
     # Prepare everything with our `accelerator`.
-    model, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-        model, optimizer, train_dataloader, lr_scheduler
+    # When using FSDP, it is efficient and recommended to call prepare for the model before creating the optimizer
+    model = accelerator.prepare(model)
+
+    optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+        optimizer, train_dataloader, lr_scheduler
     )
 
     # On TPU, the tie weights in our model have been disconnected, so we need to restore the ties.
@@ -574,6 +593,7 @@ def main():
             total_loss = 0
         for step, batch in enumerate(train_dataloader):
             # We need to skip steps until we reach the resumed step
+            step_loss_val = 0
             if args.resume_from_checkpoint and epoch == starting_epoch:
                 if resume_step is not None and step < resume_step:
                     if step % args.gradient_accumulation_steps == 0:
@@ -585,7 +605,7 @@ def main():
                 outputs = model(**batch)
                 loss = outputs.loss
                 #keeping track of the loss at each step, this is for plotting the loss
-                step_loss.append(loss.item())
+                step_loss_val += loss.detach().float()
                 # We keep track of the loss at each epoch
                 if args.with_tracking:
                     total_loss += loss.detach().float()
@@ -599,6 +619,8 @@ def main():
             if accelerator.sync_gradients:
                 progress_bar.update(1)
                 completed_steps += 1
+                step_loss.append(step_loss_val.item())
+                progress_bar.write(f"Loss at step {completed_steps}: {step_loss_val.item()}")
 
             if isinstance(checkpointing_steps, int):
                 if completed_steps % checkpointing_steps == 0 and completed_steps > 0:
@@ -612,7 +634,9 @@ def main():
 
             if completed_steps >= args.max_train_steps:
                 break
-        epoch_loss.append(total_loss.item())
+        if args.with_tracking:
+            print(f"********Loss at epoch {epoch}: {total_loss.item()}")
+            epoch_loss.append(total_loss.item())
 
         if args.push_to_hub and epoch < args.num_train_epochs - 1:
             accelerator.wait_for_everyone()

--- a/training/run_clm_no_trainer.py
+++ b/training/run_clm_no_trainer.py
@@ -394,7 +394,6 @@ def main():
     def tokenize_function(examples):
         return tokenizer(examples[text_column_name])
 
-    raw_datasets['train'] = raw_datasets['train'].select(range(1000))
 
     with accelerator.main_process_first():
         tokenized_datasets = raw_datasets.map(


### PR DESCRIPTION
This adds a flag `--optimizer_state` to the training script. When specified with a downloaded checkpoint (e.g. https://huggingface.co/EleutherAI/neox-ckpt-pythia-160m/tree/main), it allows loading in the optimizer state dict.

Note this does not change the LR or scheduler, so to the optimizer it will look like a sudden LR change. Edit the lrs yourself carefully if you want to avoid this (I figured this is better than overriding the lr with the saved one).

I had to write the loading logic myself, so there is 0 knowledge from me if this is right or not. The model doesn't blow up during training, but this doesn't mean much. I am testing this out!

Edit: I have tested this a little and made it match the deepspeed/eleuther stuff as best I can. However, now the loss does actually blow up a bit and is overall worse. I will test out loading our stuff into the eluther code and seeing what loss that gets soon.